### PR TITLE
Home sensor/relay pins now static

### DIFF
--- a/Turntable-EX.ino
+++ b/Turntable-EX.ino
@@ -41,6 +41,9 @@ const int16_t halfTurnSteps = fullTurnSteps / 2;    // Defines a half turn to en
 int16_t lastStep = 0;                               // Holds the last step value we moved to (enables least distance moves).
 int16_t lastTarget = fullTurnSteps * 2;             // Holds the last step target (prevents continuous rotatins if homing fails).
 bool homed = false;                                 // Flag to indicate if homing has been successful or not.
+const uint8_t homeSensorPin = 2;                    // Define pin 2 for the home sensor.
+const uint8_t relay1Pin = 3;                        // Control pin for relay 1.
+const uint8_t relay2Pin = 4;                        // Control pin for relay 2.
 
 // Setup our stepper object based on the standard definitions.
 #if STEPPER_CONTROLLER == ULN2003
@@ -78,7 +81,7 @@ void setupStepperDriver() {
 
 // Function to find the home position.
 void moveHome() {
-  if (digitalRead(HOME_SENSOR_PIN) == HOME_SENSOR_ACTIVE_STATE) {
+  if (digitalRead(homeSensorPin) == HOME_SENSOR_ACTIVE_STATE) {
     stepper.stop();
 #if defined(DISABLE_OUTPUTS_IDLE)
     stepper.disableOutputs();
@@ -196,12 +199,12 @@ void moveToPosition(int16_t steps, uint8_t phaseSwitch) {
 
 // If phase switching is enabled, function to set it.
 void setPhase(uint8_t phase) {
-  pinMode(RELAY1_PIN, OUTPUT);
-  pinMode(RELAY2_PIN, OUTPUT);
+  pinMode(relay1Pin, OUTPUT);
+  pinMode(relay2Pin, OUTPUT);
   Serial.print("DEBUG: Setting relay outputs for relay 1/2: ");
   Serial.println(phase);
-  digitalWrite(RELAY1_PIN, phase);
-  digitalWrite(RELAY2_PIN, phase);
+  digitalWrite(relay1Pin, phase);
+  digitalWrite(relay2Pin, phase);
 }
 
 void setup() {
@@ -214,9 +217,9 @@ void setup() {
 
 // Configure homing sensor pin
 #if HOME_SENSOR_ACTIVE_STATE == LOW
-  pinMode(HOME_SENSOR_PIN, INPUT_PULLUP);
+  pinMode(homeSensorPin, INPUT_PULLUP);
 #elif HOME_SENSOR_ACTIVE_STATE == HIGH
-  pinMode(HOME_SENSOR_PIN, INPUT);
+  pinMode(homeSensorPin, INPUT);
 #endif
 
 // Display the configured stepper details

--- a/config.example.h
+++ b/config.example.h
@@ -2,9 +2,7 @@
  *  © 2022 Peter Cole
  *
  *  This is the configuration file for Turntable-EX.
- *
- *  To define the turntable positions, edit positions.h.
-*/
+ */
 
 /////////////////////////////////////////////////////////////////////////////////////
 //  Define a valid (and free) I2C address, 0x60 is the default.
@@ -12,9 +10,10 @@
 #define I2C_ADDRESS 0x60
 
 /////////////////////////////////////////////////////////////////////////////////////
-//  Define the pin that the home sensor is connected to, and if it is active low or high.
+//  Define the active state for the homing sensor.
+//  LOW = When activated, the input is pulled down (ground or 0V).
+//  HIGH = When activated, the input is pulled up (typically 5V).
 // 
-#define HOME_SENSOR_PIN 2
 #define HOME_SENSOR_ACTIVE_STATE LOW
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -59,9 +58,3 @@
 #define STEPPER_MAX_SPEED 100     // Maximum possible speed the stepper will reach
 #define STEPPER_ACCELERATION 25   // Acceleration and deceleration rate
 #define STEPPER_SPEED 100         // Constant speed for the stepper (eg. when homing)
-
-/////////////////////////////////////////////////////////////////////////////////////
-//  If using phase switching, define the pins in use to control the relays.
-// 
-#define RELAY1_PIN 3
-#define RELAY2_PIN 4

--- a/version.h
+++ b/version.h
@@ -1,8 +1,10 @@
 #ifndef version_h
 #define version_h
 
-#define VERSION "0.0.5"
+#define VERSION "0.0.6"
 
+// 0.0.6 includes:
+//  - Move to statically defined home sensor and relay pins.
 // 0.0.5 includes:
 //  - Returns status to the TurntableEX.h device driver when requested.
 // 0.0.4 includes:


### PR DESCRIPTION
Home sensor and relay pins now defined statically.

Also remove incorrect reference to non-existing positions.h from the config example.