### PR TITLE
disable stepper after a set number of seconds

### DIFF
--- a/EX-Turntable.ino
+++ b/EX-Turntable.ino
@@ -108,9 +108,10 @@ void loop() {
     if (stepper.isRunning() != lastRunningState) {
       lastRunningState = stepper.isRunning();
       if (!lastRunningState) {
-        stepper.disableOutputs();
+        scheduleStepperDisable();
       }
     }
+    processStepperDisable();
 #endif
   }
   // Receive and process and serial input for test commands.

--- a/IOFunctions.cpp
+++ b/IOFunctions.cpp
@@ -295,6 +295,15 @@ void displayTTEXConfig() {
   Serial.print(F("STEPPER_ACCELERATION "));
   Serial.println(STEPPER_ACCELERATION);
 
+#if defined(DISABLE_OUTPUTS_IDLE)
+  Serial.println(F("DISABLE_OUTPUTS_IDLE enabled"));
+#if defined(DISABLE_OUTPUT_TIMEOUT)
+  Serial.print(F("DISABLE_OUTPUT_TIMEOUT "));
+  Serial.print(DISABLE_OUTPUT_TIMEOUT);
+  Serial.println(F(" Seconds"));
+#endif
+#endif
+
   if (debug) {
     Serial.print(F("DEBUG: maxSpeed()|acceleration(): "));
     Serial.print(stepper.maxSpeed());
@@ -434,4 +443,37 @@ void requestEvent() {
     stepperStatus = 0;
   }
   Wire.write(stepperStatus);
+}
+
+// Stepper disable timeout state
+#ifdef DISABLE_OUTPUT_TIMEOUT
+static bool _disablePending = false;
+static unsigned long _disableStartTime = 0;
+#endif
+
+// Schedule stepper outputs to be disabled. If DISABLE_OUTPUT_TIMEOUT is defined,
+// the disable is deferred; otherwise it happens immediately.
+void scheduleStepperDisable() {
+#ifdef DISABLE_OUTPUT_TIMEOUT
+  if (!_disablePending) {
+    _disablePending = true;
+    _disableStartTime = millis();
+  }
+#else
+  stepper.disableOutputs();
+#endif
+}
+
+// Call this periodically in the main loop to process any pending deferred disable.
+void processStepperDisable() {
+#ifdef DISABLE_OUTPUT_TIMEOUT
+  if (_disablePending) {
+    if (stepper.isRunning()) {
+      _disablePending = false;
+    } else if (millis() - _disableStartTime >= (DISABLE_OUTPUT_TIMEOUT * 1000UL)) {
+      stepper.disableOutputs();
+      _disablePending = false;
+    }
+  }
+#endif
 }

--- a/IOFunctions.h
+++ b/IOFunctions.h
@@ -47,5 +47,7 @@ void serialCommandV();
 void displayTTEXConfig();
 void receiveEvent(int received);
 void requestEvent();
+void scheduleStepperDisable();
+void processStepperDisable();
 
 #endif

--- a/config.example.h
+++ b/config.example.h
@@ -118,7 +118,10 @@
 //
 //  Disable the stepper controller when idling, comment out to leave on. Note that this
 //  is handy to prevent controllers overheating, so this is a recommended setting.
+//  set DISABLE_OUTPUT_TIMEOUT to disable the steppers after x seconds of no use.
 #define DISABLE_OUTPUTS_IDLE
+#define DISABLE_OUTPUT_TIMEOUT 60
+
 // 
 //  Define the acceleration and speed settings.
 #define STEPPER_MAX_SPEED 200     // Maximum possible speed the stepper will reach


### PR DESCRIPTION
set DISABLE_OUTPUT_TIMEOUT with the number of seconds, eg #define DISABLE_OUTPUT_TIMEOUT 10

Also remember to set DISABLE_OUTPUTS_IDLE first.

This way, we can ensure our turntable is steady for a period of time before being "free". i liked the idea of keeping the turntable with the power on, but figured that it didnt need to be on all the time.