### PR TITLE
if stepper is on sensor at start, rotate away then home

### DIFF
--- a/TurntableFunctions.cpp
+++ b/TurntableFunctions.cpp
@@ -176,6 +176,33 @@ void setupStepperDriver() {
 // Function to find the home position.
 void moveHome() {
   setPhase(0);
+#if defined(ROTATE_BEFORE_HOME)
+  static bool _rotateBeforeHomeDone = false;
+  static bool _clearingHome = false;
+  // Phase 1: sensor active on entry — rotate until it deactivates.
+  if (!_rotateBeforeHomeDone && !_clearingHome && !stepper.isRunning() && getHomeState() == HOME_SENSOR_ACTIVE_STATE) {
+    if (!stepper.isRunning()) {
+      Serial.println(F("Home sensor active at startup, rotating clear before homing"));
+      stepper.enableOutputs();
+      stepper.move(sanitySteps);
+    }
+    _clearingHome = true;
+    return;
+  }
+  // Phase 2: still clearing — wait for sensor to deactivate.
+  if (_clearingHome) {
+    if (getHomeState() == HOME_SENSOR_ACTIVE_STATE) {
+      return; // still on sensor, keep rotating
+    }
+    // Sensor has cleared — stop current move and let normal homing start fresh.
+    _clearingHome = false;
+    _rotateBeforeHomeDone = true;
+    stepper.stop();
+    lastTarget = sanitySteps; // reset so normal homing won't see a false failure
+    Serial.println(F("Sensor cleared, starting homing"));
+    return; // let stepper decelerate; next call starts normal homing
+  }
+#endif
   if (getHomeState() == HOME_SENSOR_ACTIVE_STATE) {
     stepper.stop();
 #if defined(DISABLE_OUTPUTS_IDLE)

--- a/config.example.h
+++ b/config.example.h
@@ -139,6 +139,14 @@
 //  #define ROTATE_REVERSE_ONLY
 
 /////////////////////////////////////////////////////////////////////////////////////
+//  If the home sensor may be active when the turntable powers on (e.g. the bridge
+//  rests on the sensor), enable this option to rotate away from the sensor before
+//  beginning the normal homing sequence. This ensures homing always triggers on a
+//  clean leading edge of the sensor.
+//
+// #define ROTATE_BEFORE_HOME
+
+/////////////////////////////////////////////////////////////////////////////////////
 //  Define the LED blink rates for fast and slow blinking in milliseconds.
 // 
 //  The LED will alternative on/off for these durations.


### PR DESCRIPTION
I was looking at how the sensor was working on my turntable, and if the turntable was already at a position where the sensor was active when powered on, it would just stay there.  I saw this could be a problem so made a change to move away from the sensor at power on, and then home from there.

